### PR TITLE
Recursive mandel

### DIFF
--- a/wasm/js/main.js
+++ b/wasm/js/main.js
@@ -190,7 +190,7 @@ document.getElementById("input").value = `
 
 const samples = document.getElementById("samples");
 
-["function.txt", "fibonacci.txt", "if.txt", "for.txt", "recurse.txt", "canvas.txt", "koch.txt", "mandel_canvas.txt"]
+["function.txt", "fibonacci.txt", "if.txt", "for.txt", "recurse.txt", "canvas.txt", "koch.txt", "mandel_canvas.txt", "mandel_canvas_recursive.txt"]
     .forEach(fileName => {
         const link = document.createElement("a");
         link.href = "#";

--- a/wasm/scripts/mandel_canvas.txt
+++ b/wasm/scripts/mandel_canvas.txt
@@ -8,31 +8,45 @@
     x 4 * y 4 * 4 4 rectangle
 } def
 
+/my_for {
+    2 index 1 +
+    2 index
+    2 index
+    my_for
+} def
+
 /mandelconverger {
     /cimag exch def
     /creal exch def
-    /iters exch def
     /imag exch def
     /real exch def
 
-    0 255 {
-        { 4 real real * imag imag * + < }
-        { }
+    /loop {
+        /iters exch def
+        /imag exch def
+        /real exch def
+
         {
-            /iters exch def
+            4 real real * imag imag * + <
+            25 iters < or
+        }
+        { iters }
+        {
             /real_next real real * imag imag * - creal + def
             /imag 2 real * imag * cimag + def
             /real real_next def
+            real imag iters 1 + loop
         } if
-    } for
-    iters
+    } def
+
+    real imag 0 loop
 } def
 
 /mandelconverge {
     /imag exch def
     /real exch def
 
-    real imag 0 real imag mandelconverger
+    real imag real imag mandelconverger
 } def
 
 /mandel {
@@ -51,7 +65,7 @@
         0 xsteps {
             /ix exch def
             /x ix xstep * xmin + def
-            x y mandelconverge
+            x y mandelconverge 10 *
             ix iy printdensity
         } for
     } for

--- a/wasm/scripts/mandel_canvas.txt
+++ b/wasm/scripts/mandel_canvas.txt
@@ -8,45 +8,31 @@
     x 4 * y 4 * 4 4 rectangle
 } def
 
-/my_for {
-    2 index 1 +
-    2 index
-    2 index
-    my_for
-} def
-
 /mandelconverger {
     /cimag exch def
     /creal exch def
+    /iters exch def
     /imag exch def
     /real exch def
 
-    /loop {
-        /iters exch def
-        /imag exch def
-        /real exch def
-
+    0 255 {
+        { 4 real real * imag imag * + < }
+        { }
         {
-            4 real real * imag imag * + <
-            25 iters < or
-        }
-        { iters }
-        {
+            /iters exch def
             /real_next real real * imag imag * - creal + def
             /imag 2 real * imag * cimag + def
             /real real_next def
-            real imag iters 1 + loop
         } if
-    } def
-
-    real imag 0 loop
+    } for
+    iters
 } def
 
 /mandelconverge {
     /imag exch def
     /real exch def
 
-    real imag real imag mandelconverger
+    real imag 0 real imag mandelconverger
 } def
 
 /mandel {
@@ -57,15 +43,13 @@
     /ymin exch def
     /xmin exch def
 
-    xstep puts xsteps puts ysteps puts ystep puts
-
     0 ysteps {
         /iy exch def
         /y iy ystep * ymin + def
         0 xsteps {
             /ix exch def
             /x ix xstep * xmin + def
-            x y mandelconverge 10 *
+            x y mandelconverge
             ix iy printdensity
         } for
     } for

--- a/wasm/scripts/mandel_canvas_recursive.txt
+++ b/wasm/scripts/mandel_canvas_recursive.txt
@@ -1,0 +1,65 @@
+
+/printdensity {
+    /y exch def
+    /x exch def
+    /d exch def
+
+    0 d 0 set_fill_style
+    x 4 * y 4 * 4 4 rectangle
+} def
+
+/mandelconverger {
+    /cimag exch def
+    /creal exch def
+    /imag exch def
+    /real exch def
+
+    /loop {
+        /iters exch def
+        /imag exch def
+        /real exch def
+
+        {
+            4 real real * imag imag * + <
+            255 iters < or
+        }
+        { iters }
+        {
+            /real_next real real * imag imag * - creal + def
+            /imag 2 real * imag * cimag + def
+            /real real_next def
+            real imag iters 1 + loop
+        } if
+    } def
+
+    real imag 0 loop
+} def
+
+/mandelconverge {
+    /imag exch def
+    /real exch def
+
+    real imag real imag mandelconverger
+} def
+
+/mandel {
+    /ysteps exch def
+    /xsteps exch def
+    /ystep exch def
+    /xstep exch def
+    /ymin exch def
+    /xmin exch def
+
+    0 ysteps {
+        /iy exch def
+        /y iy ystep * ymin + def
+        0 xsteps {
+            /ix exch def
+            /x ix xstep * xmin + def
+            x y mandelconverge
+            ix iy printdensity
+        } for
+    } for
+} def
+
+-2.0 -2.0 0.05 0.05 80 80 mandel


### PR DESCRIPTION
Add a version of mandel_canvas.txt that uses recursive calls instead of plain for loop.

Because Rustack does not have break statement, recursive call is more powerful than `for` statement (rather, `for` built-in function).
`for` built-in function is of course much faster, because it does not push a stack frame and we do not have tail call optimization.
Here is time measured on my machine.

* `for` - 7.6 seconds
* Recursive call - 21 seconds

Either way, it produces the same result in the canvas.

![image](https://github.com/msakuta/rustack/assets/2798715/d74d455a-6366-499d-ac57-8dd6b08a78ef)

